### PR TITLE
ci: add test and lint workflow for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["20", "22"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Format check
+        run: yarn format:check
+
+      - name: Test with coverage
+        run: yarn coverage
+
+      - name: Build
+        run: yarn build


### PR DESCRIPTION
## Summary
Adds continuous integration. Previously the only workflow was publish-on-`release`; nothing validated PRs.

## Changes
- Add `.github/workflows/ci.yml`: lint, format check, coverage, and build
- Node matrix: 20, 22 (the dev toolchain requires Node >=20)
- Verified all steps pass locally