### PR TITLE
docs: add CONTRIBUTING and fix CI badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+Thanks for your interest in improving `biblia-ruf`!
+
+## Getting started
+
+1. Fork and clone the repository.
+2. Install dependencies:
+   ```bash
+   yarn install
+   ```
+
+## Development workflow
+
+- **Build** (dual ESM + CJS via tsup): `yarn build`
+- **Test** (Jest): `yarn test` (watch: `yarn test:watch`)
+- **Coverage**: `yarn coverage`
+- **Lint** (ESLint): `yarn lint` (autofix: `yarn lint:fix`)
+- **Format** (Prettier): `yarn format` (check: `yarn format:check`)
+- **Validate Bible data**: `yarn validate`
+- **Run the CLI locally**: `node bin/biblia.js --help`
+
+A Husky pre-commit hook runs lint-staged and the test suite, and commit messages are
+validated against [Conventional Commits](https://www.conventionalcommits.org/) via commitlint.
+
+## Submitting changes
+
+1. Create a feature branch.
+2. Make your change with tests where appropriate.
+3. Add a changeset describing your change (this drives versioning and the changelog):
+   ```bash
+   yarn changeset
+   ```
+4. Push and open a pull request against `main`. CI runs lint, format check, coverage, and
+   build on Node 20 and 22.
+
+## Releases
+
+Releases are automated with [Changesets](https://github.com/changesets/changesets). When
+PRs with changesets land on `main`, a "Version Packages" PR is opened; merging it publishes
+to npm (with provenance) and updates `CHANGELOG.md`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![license](https://badgen.net/npm/license/biblia-ruf)](https://github.com/kulcsarrudolf/biblia-ruf/blob/main/LICENSE)
 [![downloads](https://badgen.net/npm/dt/biblia-ruf)](https://www.npmjs.com/package/biblia-ruf)
 [![GitHub Stars](https://badgen.net/github/stars/kulcsarrudolf/biblia-ruf)](https://github.com/kulcsarrudolf/biblia-ruf)
-[![tests](https://img.shields.io/github/actions/workflow/status/kulcsarrudolf/biblia-ruf/publish.yml?label=tests)](https://github.com/kulcsarrudolf/biblia-ruf/actions)
+[![CI](https://img.shields.io/github/actions/workflow/status/kulcsarrudolf/biblia-ruf/ci.yml?label=CI)](https://github.com/kulcsarrudolf/biblia-ruf/actions/workflows/ci.yml)
 
 Revideált új fordítás (RÚF) Biblia library and CLI tool. Access Bible passages, search verses, get daily verses — works in Node.js, React, and as a CLI.
 


### PR DESCRIPTION
## Summary
Documentation parity with the house standard.

## Changes
- Add `CONTRIBUTING.md` (setup, dev workflow incl. CLI/validate, changesets, releases)
- Fix the README status badge to point at `ci.yml` (was referencing the removed `publish.yml`)

(`.gitattributes` already present in this repo.)